### PR TITLE
added type validation to house, shifts, and users redux api slices

### DIFF
--- a/src/features/house/houseApiSlice.ts
+++ b/src/features/house/houseApiSlice.ts
@@ -11,7 +11,7 @@ const initialState = housesAdapter.getInitialState()
 export const housesApiSlice = apiSlice.injectEndpoints({
   endpoints: (builder) => ({
     getHouse: builder.query({
-      query: (houseId) => ({
+      query: (houseId: string) => ({
         url: `houses/${houseId}`,
         method: 'GET',
         data: { body: 'hello world' },
@@ -42,7 +42,9 @@ export const housesApiSlice = apiSlice.injectEndpoints({
       },
     }),
     addNewHouse: builder.mutation({
-      query: (data) => ({
+      query: (data: {
+        data: Partial<House>
+      }) => ({
         url: `houses`,
         method: 'POST',
         body: {
@@ -52,14 +54,17 @@ export const housesApiSlice = apiSlice.injectEndpoints({
       invalidatesTags: [{ type: 'House', id: 'LIST' }],
     }),
     updateHouses: builder.mutation({
-      query: (data) => ({
+      query: (data: {
+        houseId: string, 
+        data: Partial<House>
+      }) => ({
         url: `houses/${data.houseId}`,
         method: 'PATCH',
         body: {
           ...data.data,
         },
       }),
-      invalidatesTags: (result, error, arg) => [{ type: 'House', id: arg.id }],
+      invalidatesTags: (result, error, arg) => [{ type: 'House', id: arg.houseId }],
     }),
   }),
 })

--- a/src/features/shift/shiftApiSlice.ts
+++ b/src/features/shift/shiftApiSlice.ts
@@ -11,7 +11,7 @@ const initialState = shiftsAdapter.getInitialState()
 export const shiftsApiSlice = apiSlice.injectEndpoints({
   endpoints: (builder) => ({
     getShifts: builder.query({
-      query: (houseId) => ({
+      query: (houseId: string) => ({
         url: `houses/${houseId}/shifts`,
         method: 'GET',
         data: { body: 'hello world' },
@@ -48,7 +48,10 @@ export const shiftsApiSlice = apiSlice.injectEndpoints({
       },
     }),
     addNewShift: builder.mutation({
-      query: (data) => ({
+      query: (data: {
+        houseId: string, 
+        data: Partial<Shift>
+      }) => ({
         url: `houses/${data.houseId}/shifts`,
         method: 'POST',
         body: {
@@ -58,14 +61,18 @@ export const shiftsApiSlice = apiSlice.injectEndpoints({
       invalidatesTags: [{ type: 'Shift', id: 'LIST' }],
     }),
     updateShift: builder.mutation({
-      query: (data) => ({
+      query: (data: {
+        houseId: string,
+        shiftId: string,
+        data: Partial<Shift>
+      }) => ({
         url: `houses/${data.houseId}/shifts/${data.shiftId}`,
         method: 'PATCH',
         body: {
           ...data.data,
         },
       }),
-      invalidatesTags: (result, error, arg) => [{ type: 'Shift', id: arg.id }],
+      invalidatesTags: (result, error, arg) => [{ type: 'Shift', id: arg.shiftId }],
     }),
     // deleteShift: builder.mutation({
     //   query: ({ id }) => ({

--- a/src/features/user/userApiSlice.ts
+++ b/src/features/user/userApiSlice.ts
@@ -41,7 +41,9 @@ export const usersApiSlice = apiSlice.injectEndpoints({
       },
     }),
     addNewUser: builder.mutation({
-      query: (data) => ({
+      query: (data: {
+        data: Partial<User>
+      }) => ({
         url: `users`,
         method: 'POST',
         body: {
@@ -51,14 +53,17 @@ export const usersApiSlice = apiSlice.injectEndpoints({
       invalidatesTags: [{ type: 'User', id: 'LIST' }],
     }),
     updateUser: builder.mutation({
-      query: (data) => ({
+      query: (data: {
+        userId: string,
+        data: Partial<User>
+      }) => ({
         url: `users/${data.userId}`,
         method: 'PATCH',
         body: {
           ...data.data,
         },
       }),
-      invalidatesTags: (result, error, arg) => [{ type: 'User', id: arg.id }],
+      invalidatesTags: (result, error, arg) => [{ type: 'User', id: arg.userId }],
     }),
     // deleteUser: builder.mutation({
     //   query: ({ id }) => ({


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

## What's new in this PR
### Description
[//]: # "Required - Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."
added type validation to the data that is being passed into the get, add, and update queries for houses, users, and shifts redux API slices
now if a user tries to execute any query with invalid or inconsistent data according to our schema, it'll give them a typescript error 

### Screenshots
[//]: # "Required for frontend changes, otherwise optional but strongly recommended. Add screenshots of expected behavior - GIFs if you're feeling fancy!"
N/A

## How to review
[//]: # "Required - Describe the order in which to review files and what to expect when testing locally. Is there anything specifically you want feedback on? Should this be reviewed commit by commit, or all at once? What are some user flows to test? What are some edge cases to look out for?"
N/A

## Next steps
[//]: # "Optional - What's NOT in this PR, doesn't work yet, and/or still needs to be done. Note any temporary fixes in this PR that should be cleaned up later."
TODO: add same type validation for scheduleShifts and authorizedUsers api slices once they merged in from old repo

## Relevant Links

### Online sources
[//]: # "Optional - copy links to any tutorials or documentation that was useful to you when working on this PR"

### Related PRs
[//]: # "Optional - related PRs you're waiting on/ PRs that will conflict, etc; if this is a refactor, feel free to add PRs that previously modified this code"




[//]: # "This tags the project leader as a default. Feel free to change, or add on anyone who you should be in on the conversation."
CC: @gregoriiaaa
